### PR TITLE
Add sqlite database for guild and user configuration

### DIFF
--- a/cogs/config.py
+++ b/cogs/config.py
@@ -1,0 +1,122 @@
+import json
+from typing import List
+
+import aiosqlite
+import discord
+from discord import app_commands, Interaction
+from discord.ext import commands
+from discord.ext.commands import Context
+
+from utils.jsons import SocialsJSON
+
+
+class Config(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.db_path = "config.db"
+        self.db = None
+
+    socials = SocialsJSON().load_json()
+
+    async def cog_load(self):
+        self.db = await aiosqlite.connect(self.db_path)
+        await self.create_tables()
+
+    async def cog_unload(self):
+        await self.db.close()
+
+    async def create_tables(self):
+        await self.db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS guild_config (
+                guild_id INTEGER PRIMARY KEY,
+                config TEXT NOT NULL
+            )
+        """
+        )
+        await self.db.commit()
+
+    async def get_guild_config(self, guild_id: int):
+        async with self.db.execute(
+            "SELECT config FROM guild_config WHERE guild_id = ?", (guild_id,)
+        ) as cursor:
+            row = await cursor.fetchone()
+            if row:
+                return json.loads(row[0])
+        return json.loads("{}")
+
+    async def set_guild_config(self, guild_id: int, config: dict):
+        config_json = json.dumps(config)
+        await self.db.execute(
+            """
+            INSERT OR REPLACE INTO guild_config (guild_id, config)
+            VALUES (?, ?)
+        """,
+            (guild_id, config_json),
+        )
+        await self.db.commit()
+
+    async def get_config_value(self, guild_id: int, key: str, value: str):
+        config = await self.get_guild_config(guild_id)
+        return config.get(key, {}).get(value, self.socials.get(key, {}).get(value))
+
+    @commands.hybrid_group(
+        name="config",
+        description="Show or modify guild configuration",
+        fallback="show",
+    )
+    @app_commands.allowed_installs(guilds=True, users=False)
+    @app_commands.allowed_contexts(guilds=True, dms=False, private_channels=False)
+    @commands.has_permissions(manage_guild=True)
+    async def config_group(self, context: Context):
+        await context.send(
+            f"```json\n{json.dumps(await self.get_guild_config(context.guild.id), indent=2)}\n```"
+        )
+
+    async def social_autofix_autocompletion(
+        self, interaction: Interaction, current: str
+    ) -> List[app_commands.Choice[str]]:
+        data = []
+        for choice in list(self.socials.keys()):
+            if current.lower() in choice.lower():
+                data.append(app_commands.Choice(name=choice, value=choice))
+        return data
+
+    class SocialAutofixTransformer(app_commands.Transformer):
+        async def transform(self, interaction: discord.Interaction, value: str):
+            if value not in list(SocialsJSON().load_json().keys()):
+                return None
+
+            return value
+
+    @config_group.command(
+        name="social-autofix", description="Enable or disable social autofix per site"
+    )
+    @app_commands.describe(site="Site to modify")
+    @app_commands.autocomplete(site=social_autofix_autocompletion)
+    @app_commands.describe(enabled="Enable or disable autofix for this site")
+    @commands.has_permissions(manage_guild=True)
+    async def social_autofix(
+        self, context: Context, site: SocialAutofixTransformer, enabled: bool
+    ):
+        if site is None:
+            embed = discord.Embed(
+                color=discord.Color.red(),
+            )
+            embed.description = "No site found with that name."
+
+            await context.send(embed=embed, ephemeral=True)
+            return
+
+        config = await self.get_guild_config(context.guild.id)
+        config[site] = {}
+        config[site]["enabled"] = enabled
+        await self.set_guild_config(context.guild.id, config)
+
+        await context.send(
+            f"```json\n{json.dumps(await self.get_guild_config(context.guild.id), indent=2)}\n```"
+        )
+
+
+async def setup(bot):
+    await bot.add_cog(Config(bot))

--- a/cogs/config.py
+++ b/cogs/config.py
@@ -4,7 +4,7 @@ from typing import List
 import aiosqlite
 import discord
 from discord import Interaction, app_commands
-from discord.ext import commands
+from discord.ext import commands, tasks
 from discord.ext.commands import Context
 
 from utils.jsons import SocialsJSON, TrackingJSON
@@ -15,6 +15,13 @@ class Config(commands.Cog):
         self.bot = bot
         self.db_path = "config.db"
         self.db = None
+        self.link_fix_counts = {
+            "tiktok": 0,
+            "instagram": 0,
+            "reddit": 0,
+            "twitter": 0,
+            "songs": 0,
+        }
 
     socials = SocialsJSON().load_json()
     tracking = TrackingJSON().load_json()
@@ -22,9 +29,12 @@ class Config(commands.Cog):
     async def cog_load(self):
         self.db = await aiosqlite.connect(self.db_path)
         await self.create_tables()
+        self.sync_db_task.start()
 
     async def cog_unload(self):
-        await self.db.close()
+        if self.db:
+            await self.db.close()
+        self.sync_db_task.cancel()
 
     async def create_tables(self):
         await self.db.execute(
@@ -35,7 +45,76 @@ class Config(commands.Cog):
             )
         """
         )
+        await self.db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS link_fix_counts (
+                id INTEGER PRIMARY KEY,
+                tiktok INTEGER DEFAULT 0,
+                instagram INTEGER DEFAULT 0,
+                reddit INTEGER DEFAULT 0,
+                twitter INTEGER DEFAULT 0,
+                songs INTEGER DEFAULT 0
+            )
+        """
+        )
         await self.db.commit()
+
+    @tasks.loop(seconds=10)
+    async def sync_db_task(self):
+        async with self.db.execute(
+            "SELECT * FROM link_fix_counts WHERE id = 1"
+        ) as cursor:
+            row = await cursor.fetchone()
+            if row:
+                db_counts = dict(
+                    zip(
+                        ["id", "tiktok", "instagram", "reddit", "twitter", "songs"], row
+                    )
+                )
+                for platform in self.link_fix_counts:
+                    db_counts[platform] += self.link_fix_counts[platform]
+                    self.link_fix_counts[platform] = 0
+                await self.db.execute(
+                    "UPDATE link_fix_counts SET tiktok = ?, instagram = ?, reddit = ?, twitter = ?, songs = ? WHERE id = 1",
+                    (
+                        db_counts["tiktok"],
+                        db_counts["instagram"],
+                        db_counts["reddit"],
+                        db_counts["twitter"],
+                        db_counts["songs"],
+                    ),
+                )
+            else:
+                await self.db.execute(
+                    "INSERT INTO link_fix_counts (id, tiktok, instagram, reddit, twitter, songs) VALUES (1, ?, ?, ?, ?, ?)",
+                    tuple(self.link_fix_counts.values()),
+                )
+                self.link_fix_counts = {k: 0 for k in self.link_fix_counts}
+        await self.db.commit()
+
+        self.link_fix_counts = {k: 0 for k in self.link_fix_counts}
+
+    async def get_link_fix_counts(self):
+        async with aiosqlite.connect(self.db_path) as db:
+            async with db.execute(
+                "SELECT * FROM link_fix_counts WHERE id = 1"
+            ) as cursor:
+                row = await cursor.fetchone()
+                if row:
+                    return dict(
+                        zip(
+                            ["id", "tiktok", "instagram", "reddit", "twitter", "songs"],
+                            row,
+                        )
+                    )
+        return {
+            "id": 1,
+            "tiktok": 0,
+            "instagram": 0,
+            "reddit": 0,
+            "twitter": 0,
+            "songs": 0,
+        }
 
     async def get_guild_config(self, guild_id: int):
         async with self.db.execute(
@@ -56,6 +135,91 @@ class Config(commands.Cog):
             (guild_id, config_json),
         )
         await self.db.commit()
+
+    async def get_config_value(self, guild_id: int, key: str, value: str):
+        config = await self.get_guild_config(guild_id)
+        return config.get(key, {}).get(value, self.socials.get(key, {}).get(value))
+
+    async def make_config_embed(self, guild_id: int):
+        guild_config = await self.get_guild_config(guild_id)
+
+        embed = discord.Embed(title="Guild Configuration", color=discord.Color.blue())
+
+        for platform in self.socials:
+            config = guild_config.get(platform, {"enabled": True})
+            status = "🟢 Enabled" if config.get("enabled", True) else "🔴 Disabled"
+            embed.add_field(
+                name=platform.title().replace("Tiktok", "TikTok"),
+                value=status,
+                inline=False,
+            )
+
+        return embed
+
+    @commands.hybrid_group(
+        name="config",
+        description="Show or modify guild configuration.",
+        fallback="show",
+    )
+    @app_commands.allowed_installs(guilds=True, users=False)
+    @app_commands.allowed_contexts(guilds=True, dms=False, private_channels=False)
+    @commands.has_permissions(manage_guild=True)
+    async def config_group(self, context: Context):
+        await context.send(
+            embed=await self.make_config_embed(context.guild.id),
+        )
+
+    async def social_autofix_autocompletion(
+        self, interaction: Interaction, current: str
+    ) -> List[app_commands.Choice[str]]:
+        data = []
+        for choice in list(self.socials.keys()):
+            if current.lower() in choice.lower():
+                data.append(
+                    app_commands.Choice(
+                        name=choice.title().replace("Tiktok", "TikTok"), value=choice
+                    )
+                )
+        return data
+
+    class SocialAutofixTransformer(app_commands.Transformer):
+        async def transform(self, interaction: discord.Interaction, value: str):
+            if value not in list(SocialsJSON().load_json().keys()):
+                return None
+
+            return value
+
+    @config_group.command(
+        name="autofix", description="Enable or disable social autofix per site."
+    )
+    @app_commands.describe(site="Site to modify.")
+    @app_commands.autocomplete(site=social_autofix_autocompletion)
+    @app_commands.describe(enabled="Enable or disable autofix for this site.")
+    @commands.has_permissions(manage_guild=True)
+    async def social_autofix(
+        self, context: Context, site: SocialAutofixTransformer, enabled: bool
+    ):
+        if site is None:
+            embed = discord.Embed(
+                color=discord.Color.red(),
+            )
+            embed.description = "No site found with that name."
+
+            await context.send(embed=embed, ephemeral=True)
+            return
+
+        config = await self.get_guild_config(context.guild.id)
+        config[site] = {}
+        config[site]["enabled"] = enabled
+        await self.set_guild_config(context.guild.id, config)
+
+        await context.send(
+            embed=await self.make_config_embed(context.guild.id),
+        )
+
+    async def increment_link_fix_count(self, platform: str):
+        if platform in self.link_fix_counts:
+            self.link_fix_counts[platform] += 1
 
     async def get_config_value(self, guild_id: int, key: str, value: str):
         config = await self.get_guild_config(guild_id)

--- a/cogs/config.py
+++ b/cogs/config.py
@@ -3,7 +3,7 @@ from typing import List
 
 import aiosqlite
 import discord
-from discord import app_commands, Interaction
+from discord import Interaction, app_commands
 from discord.ext import commands
 from discord.ext.commands import Context
 

--- a/cogs/config_user.py
+++ b/cogs/config_user.py
@@ -10,14 +10,13 @@ from discord.ext.commands import Context
 from utils.jsons import SocialsJSON, TrackingJSON
 
 
-class Config(commands.Cog):
+class UserConfig(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.db_path = "config.db"
         self.db = None
 
-    socials = SocialsJSON().load_json()
-    tracking = TrackingJSON().load_json()
+    socials = TrackingJSON().load_json()
 
     async def cog_load(self):
         self.db = await aiosqlite.connect(self.db_path)
@@ -29,48 +28,50 @@ class Config(commands.Cog):
     async def create_tables(self):
         await self.db.execute(
             """
-            CREATE TABLE IF NOT EXISTS guild_config (
-                guild_id INTEGER PRIMARY KEY,
+            CREATE TABLE IF NOT EXISTS user_config (
+                user_id INTEGER PRIMARY KEY,
                 config TEXT NOT NULL
             )
         """
         )
         await self.db.commit()
 
-    async def get_guild_config(self, guild_id: int):
+    async def get_user_config(self, user_id: int):
         async with self.db.execute(
-            "SELECT config FROM guild_config WHERE guild_id = ?", (guild_id,)
+            "SELECT config FROM user_config WHERE user_id = ?", (user_id,)
         ) as cursor:
             row = await cursor.fetchone()
             if row:
                 return json.loads(row[0])
         return json.loads("{}")
 
-    async def set_guild_config(self, guild_id: int, config: dict):
+    async def set_user_config(self, user_id: int, config: dict):
         config_json = json.dumps(config)
         await self.db.execute(
             """
-            INSERT OR REPLACE INTO guild_config (guild_id, config)
+            INSERT OR REPLACE INTO user_config (user_id, config)
             VALUES (?, ?)
         """,
-            (guild_id, config_json),
+            (user_id, config_json),
         )
         await self.db.commit()
 
-    async def get_config_value(self, guild_id: int, key: str, value: str):
-        config = await self.get_guild_config(guild_id)
-        return config.get(key, {}).get(value, self.socials.get(key, {}).get(value))
+    async def get_config_value(self, user_id: int, key: str, value: str):
+        config = await self.get_user_config(user_id)
+        return config.get(key, {}).get(
+            value, self.socials.get(key, {}).get(value, True)
+        )
 
-    async def make_config_embed(self, guild_id: int):
-        guild_config = await self.get_guild_config(guild_id)
+    async def make_config_embed(self, user_id: int):
+        user_config = await self.get_user_config(user_id)
 
-        embed = discord.Embed(title="Guild Configuration", color=discord.Color.blue())
+        embed = discord.Embed(title="User Configuration", color=discord.Color.blue())
 
         for platform in self.socials:
-            config = guild_config.get(platform, {"enabled": True})
+            config = user_config.get(platform, {"enabled": True})
             status = "🟢 Enabled" if config.get("enabled", True) else "🔴 Disabled"
             embed.add_field(
-                name=platform.title().replace("Tiktok", "TikTok"),
+                name=platform.title().replace("Tiktok", "TikTok") + " Tracking Warning",
                 value=status,
                 inline=False,
             )
@@ -78,16 +79,16 @@ class Config(commands.Cog):
         return embed
 
     @commands.hybrid_group(
-        name="config",
-        description="Show or modify guild configuration.",
+        name="preferences",
+        description="Show or modify user configuration.",
         fallback="show",
     )
     @app_commands.allowed_installs(guilds=True, users=False)
     @app_commands.allowed_contexts(guilds=True, dms=False, private_channels=False)
-    @commands.has_permissions(manage_guild=True)
     async def config_group(self, context: Context):
         await context.send(
-            embed=await self.make_config_embed(context.guild.id),
+            embed=await self.make_config_embed(context.author.id),
+            ephemeral=True
         )
 
     async def social_autofix_autocompletion(
@@ -111,13 +112,13 @@ class Config(commands.Cog):
             return value
 
     @config_group.command(
-        name="autofix", description="Enable or disable social autofix per site."
+        name="tracking",
+        description="Enable or disable tracking warnings per site.",
     )
     @app_commands.describe(site="Site to modify.")
     @app_commands.autocomplete(site=social_autofix_autocompletion)
-    @app_commands.describe(enabled="Enable or disable autofix for this site.")
-    @commands.has_permissions(manage_guild=True)
-    async def social_autofix(
+    @app_commands.describe(enabled="Enable or disable tracking warnings for this site.")
+    async def tracking(
         self, context: Context, site: SocialAutofixTransformer, enabled: bool
     ):
         if site is None:
@@ -129,15 +130,16 @@ class Config(commands.Cog):
             await context.send(embed=embed, ephemeral=True)
             return
 
-        config = await self.get_guild_config(context.guild.id)
+        config = await self.get_user_config(context.author.id)
         config[site] = {}
         config[site]["enabled"] = enabled
-        await self.set_guild_config(context.guild.id, config)
+        await self.set_user_config(context.author.id, config)
 
         await context.send(
-            embed=await self.make_config_embed(context.guild.id),
+            embed=await self.make_config_embed(context.author.id),
+            ephemeral=True
         )
 
 
 async def setup(bot):
-    await bot.add_cog(Config(bot))
+    await bot.add_cog(UserConfig(bot))

--- a/cogs/config_user.py
+++ b/cogs/config_user.py
@@ -87,8 +87,7 @@ class UserConfig(commands.Cog):
     @app_commands.allowed_contexts(guilds=True, dms=False, private_channels=False)
     async def config_group(self, context: Context):
         await context.send(
-            embed=await self.make_config_embed(context.author.id),
-            ephemeral=True
+            embed=await self.make_config_embed(context.author.id), ephemeral=True
         )
 
     async def social_autofix_autocompletion(
@@ -136,8 +135,7 @@ class UserConfig(commands.Cog):
         await self.set_user_config(context.author.id, config)
 
         await context.send(
-            embed=await self.make_config_embed(context.author.id),
-            ephemeral=True
+            embed=await self.make_config_embed(context.author.id), ephemeral=True
         )
 
 

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -14,17 +14,14 @@ from discord import app_commands
 from discord.ext import commands
 from discord.ext.commands import Context
 
+from utils.jsons import ConfigJSON
+
 
 class Owner(commands.Cog, name="owner"):
     def __init__(self, bot) -> None:
         self.bot = bot
 
-    path = os.path.dirname(os.path.realpath(__file__))
-    path = os.path.dirname(path)
-    path = os.path.join(path, "config/config.json")
-
-    with open(path) as file:
-        config = json.load(file)
+    config = ConfigJSON().load_json()
 
     @commands.command(
         name="sync",

--- a/cogs/socials.py
+++ b/cogs/socials.py
@@ -532,6 +532,7 @@ class Socials(commands.Cog, name="socials"):
                 mention_author=False,
                 view=view,
             )
+            await self.config_cog.increment_link_fix_count("tiktok")
         else:
             msg = org_msg + tracking_warning
             if message.channel.permissions_for(message.guild.me).send_messages:
@@ -540,6 +541,7 @@ class Socials(commands.Cog, name="socials"):
                     mention_author=False,
                     view=view,
                 )
+                await self.config_cog.increment_link_fix_count("tiktok")
                 if tracking:
                     await asyncio.sleep(0.75)
                     with suppress(discord.errors.Forbidden, discord.errors.NotFound):
@@ -595,11 +597,13 @@ class Socials(commands.Cog, name="socials"):
 
         if context:
             await context.send(org_msg, mention_author=False)
+            await self.config_cog.increment_link_fix_count("instagram")
         else:
             if message.channel.permissions_for(message.guild.me).send_messages:
                 fixed = await message.reply(
                     warn_msg if tracking else org_msg, mention_author=False
                 )
+                await self.config_cog.increment_link_fix_count("instagram")
                 if tracking:
                     await asyncio.sleep(0.75)
                     with suppress(discord.errors.Forbidden, discord.errors.NotFound):
@@ -663,11 +667,13 @@ class Socials(commands.Cog, name="socials"):
                     await context.send(
                         link if not spoiler else f"||{link}||", mention_author=False
                     )
+                    await self.config_cog.increment_link_fix_count("reddit")
                 else:
                     if message.channel.permissions_for(message.guild.me).send_messages:
                         await message.reply(
                             link if not spoiler else f"||{link}||", mention_author=False
                         )
+                        await self.config_cog.increment_link_fix_count("reddit")
                         await asyncio.sleep(0.75)
                         with suppress(
                             discord.errors.Forbidden, discord.errors.NotFound
@@ -681,9 +687,11 @@ class Socials(commands.Cog, name="socials"):
                 embed.set_footer(text=f"NSFW • {footer}")
             if context:
                 await context.send(embed=embed, file=file, mention_author=False)
+                await self.config_cog.increment_link_fix_count("reddit")
             else:
                 if message.channel.permissions_for(message.guild.me).send_messages:
                     await message.reply(embed=embed, file=file, mention_author=False)
+                    await self.config_cog.increment_link_fix_count("reddit")
                     await asyncio.sleep(0.75)
                     with suppress(discord.errors.Forbidden, discord.errors.NotFound):
                         await message.edit(suppress=True)
@@ -712,11 +720,13 @@ class Socials(commands.Cog, name="socials"):
             await context.send(
                 link if not spoiler else f"||{link}||", mention_author=False
             )
+            await self.config_cog.increment_link_fix_count("twitter")
         else:
             if message.channel.permissions_for(message.guild.me).send_messages:
                 await message.reply(
                     link if not spoiler else f"||{link}||", mention_author=False
                 )
+                await self.config_cog.increment_link_fix_count("twitter")
                 await asyncio.sleep(0.75)
                 with suppress(discord.errors.Forbidden, discord.errors.NotFound):
                     await message.edit(suppress=True)

--- a/cogs/songs.py
+++ b/cogs/songs.py
@@ -75,6 +75,7 @@ class Songs(commands.Cog, name="songs"):
         if match := self.pattern.search(message.content.strip("<>")):
             link = match.group(0)
             await self.generate_view(message, link)
+            await self.config_cog.increment_link_fix_count("songs")
             return
 
     @cached(ttl=86400)

--- a/cogs/songs.py
+++ b/cogs/songs.py
@@ -9,6 +9,7 @@ from aiocache import cached
 from discord.ext import commands
 
 from utils.colorthief import get_color
+from utils.jsons import SocialsJSON
 
 platforms = {
     "spotify": {"name": "Spotify", "emote": "<:Music_Spotify:958786315883794532>"},
@@ -23,6 +24,8 @@ platforms = {
 class Songs(commands.Cog, name="songs"):
     def __init__(self, bot):
         self.bot = bot
+        self.config = SocialsJSON().load_json()
+        self.config_cog = self.bot.get_cog("Config")
         self.pattern = re.compile(
             r"https:\/\/(open\.spotify\.com\/track\/[A-Za-z0-9]+|"
             r"music\.apple\.com\/[a-zA-Z]{2}\/album\/[a-zA-Z\d%\(\)-]+\/[\d]{1,10}\?i=[\d]{1,15}|"
@@ -37,11 +40,22 @@ class Songs(commands.Cog, name="songs"):
             r"music\.youtube\.com\/watch\?v=[A-Za-z0-9_-]{11})"
         )
 
+    async def check_enabled(self, site: str, config, guild_id: int = None):
+        if guild_id is None:
+            if not self.config[site]["enabled"]:
+                return False
+        else:
+            if not await self.config_cog.get_config_value(guild_id, site, "enabled"):
+                return False
+        return True
+
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
         if not message.guild:
             return
         if message.author.bot and not message.author.id == 356268235697553409:
+            return
+        if not await self.check_enabled("songs", self.config, message.guild.id):
             return
         if message.author.bot and message.author.id == 356268235697553409:
             if message.embeds:

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -34,6 +34,8 @@ class Utilities(commands.Cog, name="utilities"):
     async def on_message_edit(self, before, after):
         if not before.guild:
             return
+        if before.content == after.content:
+            return
         if before.channel.id not in self.last_logged_messages:
             self.last_logged_messages[before.channel.id] = []
         self.last_logged_messages[before.channel.id].append(("edit", before, after))
@@ -113,7 +115,7 @@ class Utilities(commands.Cog, name="utilities"):
         embed.add_field(name="Discord.py Version", value=discord.__version__)
         embed.add_field(
             name="RAM Usage",
-            value=f"{int(psutil.Process().memory_info().rss / 1024 ** 2)} / {int(psutil.virtual_memory().total / 1024 ** 2)} MB",
+            value=f"{int(psutil.virtual_memory().used / 1024 ** 2)} MB ({int(psutil.Process().memory_info().rss / 1024 ** 2)} MB) / {int(psutil.virtual_memory().total / 1024 ** 2)} MB",
         )
         embed.add_field(name="Host", value=platform.system() + " " + platform.release())
         embed.add_field(name="Website", value="https://keto.boats", inline=False)

--- a/config/socials.json
+++ b/config/socials.json
@@ -16,5 +16,8 @@
   "twitter": {
     "enabled": true,
     "url": "twittpr.com"
+  },
+  "songs": {
+    "enabled": true
   }
 }

--- a/config/socials.json
+++ b/config/socials.json
@@ -16,9 +16,5 @@
   "twitter": {
     "enabled": true,
     "url": "twittpr.com"
-  },
-  "youtubeshorts": {
-    "enabled": false,
-    "url": "yt.lillieh1000.gay/?videoID="
   }
 }

--- a/config/tracking.json
+++ b/config/tracking.json
@@ -1,0 +1,8 @@
+{
+  "tiktok": {
+    "enabled": true
+  },
+  "instagram": {
+    "enabled": true
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ tomli==2.0.1
 typing_extensions==4.9.0
 yarl==1.9.4
 psutil==6.0.0
+aiosqlite==0.20.0

--- a/utils/context_commands.py
+++ b/utils/context_commands.py
@@ -8,6 +8,8 @@ import discord
 from discord import Interaction, app_commands
 from discord.ext import commands
 
+from utils.jsons import ConfigJSON
+
 
 class PFPView(discord.ui.View):
     def __init__(self, interaction: Interaction, embed=discord.Embed):
@@ -61,12 +63,7 @@ class PFPButton(discord.ui.Button):
         await interaction.response.edit_message(embed=embed)
 
 
-path = os.path.dirname(os.path.realpath(__file__))
-path = os.path.dirname(path)
-path = os.path.join(path, "config/config.json")
-
-with open(path) as file:
-    config = json.load(file)
+config = ConfigJSON().load_json()
 
 
 async def handle_avatar(interaction: Interaction, member: discord.Member):

--- a/utils/jsons.py
+++ b/utils/jsons.py
@@ -1,0 +1,25 @@
+import json
+
+
+class JSONObject(object):
+    def __init__(self, path: str) -> None:
+        self.path = path  # TODO: not sure if pathlib is better but using str for now
+
+    @staticmethod
+    def __load__(data):
+        return data
+
+    def load_json(self):
+        with open(self.path, "r") as f:
+            result = JSONObject.__load__(json.loads(f.read()))
+        return result
+
+
+class ConfigJSON(JSONObject):
+    def __init__(self) -> None:
+        super().__init__("config/config.json")
+
+
+class SocialsJSON(JSONObject):
+    def __init__(self) -> None:
+        super().__init__("config/socials.json")

--- a/utils/jsons.py
+++ b/utils/jsons.py
@@ -23,3 +23,8 @@ class ConfigJSON(JSONObject):
 class SocialsJSON(JSONObject):
     def __init__(self) -> None:
         super().__init__("config/socials.json")
+
+
+class TrackingJSON(JSONObject):
+    def __init__(self) -> None:
+        super().__init__("config/tracking.json")


### PR DESCRIPTION
To-do list:
- [x] Config cog
- [x] Make socials cog respect guild configuration
- [ ] Add extra settings to guild configuration, other than enabled (block-tracking, build-embeds, etc.)
- [ ] Organize autocompleters/transformers
- [ ] Audit and make sure is SQL injection resistant (likely is due to the transformer and autocompleter)
- [ ] Proper success messages on config set
- [ ] Add user configuration
    - [ ] Will be a separate command due to Discord limitations on sub-command groups (probably /preferences)
    - [ ] Merge user and guild into same config cog and database